### PR TITLE
Change form-in-form selector

### DIFF
--- a/includes/js/src/index.js
+++ b/includes/js/src/index.js
@@ -48,7 +48,7 @@ document.addEventListener( 'DOMContentLoaded', event => {
 	};
 
 	document.querySelectorAll(
-		'form .wpcf7' // form-in-form situation
+		'form form.wpcf7' // form-in-form situation
 	).forEach( div => {
 		const error = document.createElement( 'p' );
 		error.setAttribute( 'class', 'wpcf7-form-in-wrong-place' );


### PR DESCRIPTION
Changes the selector for testing whether a wpcf7 form is nested from `form .wpcf7` to `form form.wpcf7`